### PR TITLE
Fixed various bugs

### DIFF
--- a/src/pd_explain/explainable_data_frame.py
+++ b/src/pd_explain/explainable_data_frame.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 from matplotlib.axis import Axis
+from pandas import DataFrame
 from pandas._libs.lib import no_default
 
 # importing sys
@@ -21,7 +22,7 @@ from typing import (
     Hashable,
     Sequence,
     Union,
-    List,
+    List, Callable,
 )
 from pandas._typing import Level, Renamer, IndexLabel, Axes, Dtype
 
@@ -69,13 +70,20 @@ class ExpDataFrame(pd.DataFrame):
         self.explanation = None
         self.filter_items = None
 
+    # We overwrite the constructor to ensure that an ExpDataFrame is returned when a new DataFrame is created.
+    # This is necessary so that methods not overridden in this class, like iloc, return an ExpDataFrame.
     @property
-    def _constructor(self):
-        return ExpDataFrame
+    def _constructor(self) -> Callable[..., DataFrame]:
 
-    @property
-    def _constructor_sliced(self):
-        return ExpSeries
+        # We define a new constructor that returns an ExpDataFrame, with the same properties as the original dataframe.
+        def _c(*args, **kwargs):
+            df = ExpDataFrame(*args, **kwargs)
+            df.operation = self.operation
+            df.explanation = self.explanation
+            df.filter_items = self.filter_items
+            return df
+
+        return _c
 
     def __getitem__(self, key):
         """

--- a/src/pd_explain/explainable_data_frame.py
+++ b/src/pd_explain/explainable_data_frame.py
@@ -34,7 +34,7 @@ from pd_explain.explainable_series import ExpSeries
 
 class ExpDataFrame(pd.DataFrame):
     """
-    Explainable dataframe, extents Pandas DataFrame adding state management and explain() function.
+    Explainable dataframe, extends Pandas DataFrame adding state management and explain() function.
     """
 
     def __init__(
@@ -245,8 +245,8 @@ class ExpDataFrame(pd.DataFrame):
 
                 if columns is not None and self.operation.attribute in columns:
                     self.operation.attribute = columns[self.operation.attribute]
-                # In the case of a mapper, we only care about making the update to the operation if it affects the columns.
 
+                # In the case of a mapper, we only care about making the update to the operation if it affects the columns.
                 elif mapper is not None and axis == 'columns':
 
                     # If the mapper is of the form {old_name: new_name}, we need to update the attribute name if it was
@@ -281,7 +281,7 @@ class ExpDataFrame(pd.DataFrame):
                     elif callable(mapper):
                         self.operation.group_attributes = [mapper(attr) for attr in group_attributes]
 
-        # Then return the result.
+        # Return the result. None if inplace=True, otherwise the new dataframe.
         return res
 
     def sample(
@@ -574,14 +574,8 @@ class ExpDataFrame(pd.DataFrame):
             right_df = ExpDataFrame(other.copy())
             right_df.df_name = right_name
 
-            # ignore_columns = [attribute for attribute in on] if on is not None else []
-            # ignore_columns.append('index')
-            # self.columns = [col if col in ignore_columns else left_name + "_" + col
-            # for col in self]
-            # right_df.columns = [col if col in ignore_columns else right_name + "_" + col
-            # for col in right_df]
-            result_df = ExpDataFrame(pd.merge(self, right_df, on=on, left_on=left_on, right_on=right_on, how=how))
-            # result_df = ExpDataFrame(super().join(right_df, on, how, lsuffix, rsuffix, sort))
+            result_df = ExpDataFrame(pd.merge(self, right_df, on=on, left_on=left_on,
+                                              right_on=right_on, how=how, suffixes=(lsuffix, rsuffix), sort=sort))
             result_df.operation = Join(self, right_df, None, on, result_df, left_name, right_name)
 
             return result_df

--- a/src/pd_explain/explainable_data_frame.py
+++ b/src/pd_explain/explainable_data_frame.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from copy import copy
 
 import numpy as np
@@ -650,6 +651,11 @@ class ExpDataFrame(pd.DataFrame):
         :return: A Explain DataFrame of the two merged objects with join operation filed.
         """
         try:
+            # If no on is specified, we raise a warning to let the user know that the operation and explanation may not
+            # work as expected.
+            if on is None:
+                warnings.warn("No 'on' parameter specified in join operation. The operation and explanation may not work as expected.")
+
             left_name = utils.get_calling_params_name(self)
             right_name = utils.get_calling_params_name(other)
             self = self.reset_index()
@@ -670,9 +676,9 @@ class ExpDataFrame(pd.DataFrame):
             coinciding_cols = set(left_cols) & set(right_cols)
             left_df = self.copy()
             right_df = right_df.copy()
-            for col in coinciding_cols:
-                left_df.rename(columns={col: col + lsuffix}, inplace=True)
-                right_df.rename(columns={col: col + rsuffix}, inplace=True)
+
+            left_df.rename(columns={col: col + lsuffix for col in coinciding_cols}, inplace=True)
+            right_df.rename(columns={col: col + rsuffix for col in coinciding_cols}, inplace=True)
 
             result_df.operation = Join(left_df, right_df, None, on, result_df, left_name, right_name)
 

--- a/src/pd_explain/explainable_data_frame.py
+++ b/src/pd_explain/explainable_data_frame.py
@@ -135,6 +135,10 @@ class ExpDataFrame(pd.DataFrame):
         :return: Explain DataFrame without the removed index or column labels or None if inplace=True.
         """
         if inplace:
+            # Perform the dropping, and set res to None as we are doing the operation inplace.
+            super(ExpDataFrame, self).drop(labels=labels, axis=axis, index=index, columns=columns, level=level,
+                                           inplace=inplace, errors=errors)
+            res = None
             # When doing an inplace drop, we need to update the source dataframe of the operation.
             # Otherwise, the operation may use the old dataframes or cause an error.
             # Please note that this can cause a recursive call, as the source_df should also be an ExpDataFrame.
@@ -143,11 +147,7 @@ class ExpDataFrame(pd.DataFrame):
                 if self.operation.source_df is not None:
                     self.operation.source_df.drop(labels=labels, axis=axis, index=index, columns=columns, level=level,
                                                   inplace=inplace, errors=errors)
-            # Perform the dropping, and save the result to a variable so we can return it later.
-            super(ExpDataFrame, self).drop(labels=labels, axis=axis, index=index, columns=columns, level=level,
-                                           inplace=inplace, errors=errors)
-            self.operation.result_df = self
-            res = self
+                self.operation.result_df = self
 
         else:
             # If the operation is not inplace, we can just return the new dataframe.
@@ -198,6 +198,10 @@ class ExpDataFrame(pd.DataFrame):
         :return: Explain DataFrame with the renamed axis labels or None if inplace=True.
         """
         if inplace:
+            # Perform the renaming, and set res to None as we are doing the operation inplace.
+            super(ExpDataFrame, self).rename(mapper=mapper, index=index, columns=columns, axis=axis,
+                                             copy=copy, inplace=inplace, level=level, errors=errors)
+            res = None
             # When doing an inplace rename, we need to update the source dataframe of the operation.
             # Otherwise, the operation may use the old dataframes or cause an error.
             # Please note that this can cause a recursive call, as the source_df should also be an ExpDataFrame.
@@ -207,10 +211,8 @@ class ExpDataFrame(pd.DataFrame):
                     self.operation.source_df.rename(mapper=mapper, index=index, columns=columns, axis=axis,
                                                     copy=copy, inplace=inplace, level=level, errors=errors)
             # Perform the renaming, and save the result to a variable so we can return it later.
-            super(ExpDataFrame, self).rename(mapper=mapper, index=index, columns=columns, axis=axis,
-                                             copy=copy, inplace=inplace, level=level, errors=errors)
-            self.operation.result_df = self
-            res = self
+
+                self.operation.result_df = self
         else:
             # If the operation is not inplace, we can just return the new dataframe.
             # However, we need to make sure to update the operation of the new dataframe, as otherwise we may get a

--- a/src/pd_explain/explainable_group_by_dataframe.py
+++ b/src/pd_explain/explainable_group_by_dataframe.py
@@ -416,6 +416,7 @@ class ExpDataFrameGroupBy(DataFrameGroupBy):
             return original_result
 
         return result
+
     def drop_duplicates(
             self,
     ) -> ExpDataFrame | None:
@@ -462,4 +463,4 @@ class ExpDataFrameGroupBy(DataFrameGroupBy):
             return
         mean_agg = self.mean()
         mean_agg.explain(schema=schema, attributes=attributes, top_k=top_k, explainer='fedex', target=target, dir=dir,
-                                      figs_in_row=figs_in_row, show_scores=show_scores, title=title, ignore=ignore)
+                         figs_in_row=figs_in_row, show_scores=show_scores, title=title, ignore=ignore)

--- a/src/pd_explain/explainable_group_by_series.py
+++ b/src/pd_explain/explainable_group_by_series.py
@@ -27,7 +27,8 @@ class ExpSeriesGroupBy(SeriesGroupBy):
                  mutated: bool = False,
                  dropna: bool = True,
                  ):
-        super().__init__(obj=obj, keys=keys, axis=axis, level=level, grouper=grouper, exclusions=exclusions, selection=selection, as_index=as_index
+        super().__init__(obj=obj, keys=keys, axis=axis, level=level, grouper=grouper, exclusions=exclusions,
+                         selection=selection, as_index=as_index
                          , sort=sort,
                          group_keys=group_keys, observed=observed)
 
@@ -363,6 +364,7 @@ class ExpSeriesGroupBy(SeriesGroupBy):
             return original_result
 
         return result
+
     def drop_duplicates(
             self,
     ) -> ExpDataFrame | None:

--- a/src/pd_explain/explainable_series.py
+++ b/src/pd_explain/explainable_series.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List
+from typing import List, Literal
 
 import pandas as pd
 from pandas._typing import Dtype
@@ -171,7 +171,7 @@ class ExpSeries(pd.Series):
 
     def explain(self, schema: dict = None, attributes: List = None, top_k: int = 1, figs_in_row: int = 2,
                 explainer='fedex',
-                target=None, dir=None, control=None, hold_out=[],
+                target=None, dir: Literal["high", "low", 1, -1]=None, control=None, hold_out=[],
                 show_scores: bool = False, title: str = None):
         """
         Generate explanation to series base on the operation lead to this series result
@@ -182,16 +182,21 @@ class ExpSeries(pd.Series):
         :param figs_in_row: number of explanations figs in one row
         :param show_scores: show scores on explanation
         :param title: explanation title
+        :param explainer: explanation method, default is fedex. Options are fedex or outlier.
+        :param target: outlier target value to explain
+        :param dir: direction of the outlier. Can be 'high' or 'low' (or corresponding integer values 1 and -1) when using
+                    the outlier explainer. Default is None.
 
         :return: explanation figures
         """
-        # if explainer == 'outlier':
+        if explainer == 'outlier':
+            if dir is None:
+                raise ValueError('dir must be provided for outlier explanation')
+            if dir not in ['high', 'low', 1, -1]:
+                raise ValueError('dir must be either high or low or the corresponding integer values 1 and -1')
+            if target is None:
+                raise ValueError('target value must be provided for outlier explanation')
 
-        #     df = pd.read_csv(df_loc)
-        #     new_songs = df[df.year > 1990]
-        #     m_p_by_decade = new_songs.groupby('decade').mean()['popularity']
-        #     self.explain_outlier(m_p_by_decade, new_songs, 'decade', 'popularity', 2020)
-        #     return
         if attributes is None:
             attributes = []
 


### PR DESCRIPTION
Fixed the following bugs:

- Dropped columns would still appear in explanations of GroupBy operations after an in-place drop.
- Renamed columns would appear with their old names in explanations of GroupBy operations after an in-place rename.
- Calling explain on a filter operation after an in-place column rename would cause an AttributeError.
- Calling explain after a join where suffixes were added would cause a KeyError.
- Calling explain for any operation after calling a not in-place drop or rename would return "no operation found" instead.
- Calling any non-overridden function that modifies the dataframe would return a DataFrame object instead of a ExpDataFrame object.
- Renaming or dropping a column in-place after a join would cause a KeyError when calling explain.
- Calling outlier explainer without specifying "target" or "dir" would cause the algorithm to run and always return "no explanation was found". Doing this now immediately raises an error.
- Calling outlier explainer on a dataframe (and not a series) would raise a non-informative AttributeError. It now instead raises an informative error to the user.
- lsuffix and rsuffix parameters would be ignored when performing a join, leading to the default suffixes of _x and _y to always be used instead.
- Calling explain on a join operation that had suffixes attached would cause a KeyError.
- Calling df.groupby(attribute)[column selection].agg_func() and then explain would generate an explanation, but calling df.groupby(attribute).agg_func()[column_selection] would return "no operation found". This ordering does not matter anymore.
- After performing column selection, i.e. df[columns] and then calling explain, columns not selected would still appear in the explanation.

These fixes were mostly done by modifying ExpDataFrame, specifically the rename, drop and __getitem__ methods, as well overriding the _constructor property of pd.DataFrame.
Changes to other files, except for several lines in ExpSeries.py adding errors to missing outputs for outlier explainer, are purely just formatting the files, using an auto formatter to improve readability.