### PR TITLE
Outlier explainer integration update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ python-dotenv>=0.20.0
 singleton-decorator
 matplotlib>=3.5.1
 setuptools>=60.2.0
-fedex-generator>=1.0.4
+fedex-generator>=1.0.5
 cluster-explorer >= 1.0.1
+external-explainers>=1.0.0
 pytest>=6.2.4

--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,9 @@ setup(
         'python-dotenv',
         'singleton-decorator',
         'matplotlib',
-        'fedex-generator>=1.0.4',
+        'fedex-generator>=1.0.5',
         'cluster-explorer>=1.0.1',
+        'external-explainers>=1.0.0'
     ]
 
 )

--- a/src/pd_explain/core/explainable_data_frame.py
+++ b/src/pd_explain/core/explainable_data_frame.py
@@ -16,6 +16,7 @@ import sys
 sys.path.insert(0, 'C:/Users/itaye/Desktop/pdexplain/FEDEx_Generator-1/src/')
 sys.path.insert(0, "C:\\Users\\Yuval\\PycharmProjects\\FEDEx_Generator\\src")
 sys.path.insert(0, "C:\\Users\\Yuval\\PycharmProjects\\cluster-explorer\\src")
+sys.path.insert(0, "C:\\Users\Yuval\\PycharmProjects\\ExternalExplainers\\src")
 # sys.path.insert(0, 'C:/Users/User/Desktop/pd_explain_test/FEDEx_Generator-1/src')
 from fedex_generator.Operations.Filter import Filter
 from fedex_generator.Operations.GroupBy import GroupBy

--- a/src/pd_explain/explainers/explainer_factory.py
+++ b/src/pd_explain/explainers/explainer_factory.py
@@ -1,5 +1,7 @@
-from .fedex_explainer import FedexExplainer
-from .many_to_one_explainer import ManyToOneExplainer
+from pd_explain.explainers.fedex_explainer import FedexExplainer
+from pd_explain.explainers.many_to_one_explainer import ManyToOneExplainer
+from pd_explain.explainers.outlier_explainer import OutlierExplainerInterface as OutlierExplainer
+
 from singleton_decorator import singleton
 
 @singleton
@@ -17,8 +19,11 @@ class ExplainerFactory:
         :param kwargs: The arguments to pass to the explainer.
         :return: The explainer object.
         """
-        if explainer == "fedex" or explainer == 'outlier' or explainer == 'shapley':
+        explainer = explainer.lower()
+        if explainer == "fedex" or explainer == 'shapley':
             return FedexExplainer(explainer=explainer,*args, **kwargs)
+        elif explainer == 'outlier':
+            return OutlierExplainer(*args, **kwargs)
         elif explainer.replace("_", " ") == "many to one":
             return ManyToOneExplainer(*args, **kwargs)
         else:

--- a/src/pd_explain/explainers/fedex_explainer.py
+++ b/src/pd_explain/explainers/fedex_explainer.py
@@ -12,11 +12,8 @@ class FedexExplainer(ExplainerInterface):
     """
 
     def __init__(self, operation=None, schema: dict = None, attributes: List = None, top_k: int = None,
-                 explainer='fedex',
-                 target=None,
-                 dir=None,
-                 figs_in_row: int = 2, show_scores: bool = False, title: str = None, corr_TH: float = 0.7,
-                 consider='right', value=None, attr=None, ignore=None, hold_out=None, control=None,
+                 explainer='fedex', figs_in_row: int = 2, show_scores: bool = False, title: str = None,
+                 corr_TH: float = 0.7, consider='right', value=None, attr=None, ignore=None,
                  use_sampling: bool = True, sample_size = 5000, *args, **kwargs):
         """
         Initialize the FedexExplainer object.
@@ -38,20 +35,7 @@ class FedexExplainer(ExplainerInterface):
         """
 
         if operation is None:
-            raise ValueError('All fedex explainers and outlier explainer require an operation object')
-
-        if hold_out is None:
-            hold_out = []
-        if ignore is None:
-            ignore = []
-
-        if explainer == 'outlier':
-            if dir is None:
-                raise ValueError('dir must be provided for outlier explanation')
-            if dir not in ['high', 'low', 1, -1]:
-                raise ValueError('dir must be either high or low or the corresponding integer values 1 and -1')
-            if target is None:
-                raise ValueError('target value must be provided for outlier explanation')
+            raise ValueError('All fedex explainers require an operation object')
 
         if schema is None:
             schema = {}
@@ -77,8 +61,6 @@ class FedexExplainer(ExplainerInterface):
         self._attributes = attributes
         self._top_k = top_k
         self._explainer = explainer
-        self._target = target
-        self._dir = dir
         self._figs_in_row = figs_in_row
         self._show_scores = show_scores
         self._title = title
@@ -88,8 +70,6 @@ class FedexExplainer(ExplainerInterface):
         self._attr = attr
         self._ignore = ignore
         self._operation = operation
-        self._hold_out = hold_out
-        self._control = control
         self._results = None
         self._use_sampling = use_sampling
         self._sample_size = sample_size
@@ -98,16 +78,6 @@ class FedexExplainer(ExplainerInterface):
         if self._operation is None:
             self._results = "No operation was found."
             return self._results
-
-        if self._explainer == 'outlier':
-            self._results = self._operation.explain(
-                schema=self._schema, attributes=self._attributes, top_k=self._top_k, explainer=self._explainer,
-                target=self._target, dir=self._dir,
-                control=self._control, hold_out=self._hold_out, figs_in_row=self._figs_in_row,
-                show_scores=self._show_scores, title=self._title, corr_TH=self._corr_TH,
-                consider=self._consider, cont=self._value, attr=self._attr, ignore=self._ignore,
-                use_sampling=self._use_sampling, sample_size=self._sample_size
-            )
 
         else:
             self._results = self._operation.explain(

--- a/src/pd_explain/explainers/outlier_explainer.py
+++ b/src/pd_explain/explainers/outlier_explainer.py
@@ -1,0 +1,83 @@
+from pd_explain.explainers.explainer_interface import ExplainerInterface
+from external_explainers import OutlierExplainer
+from fedex_generator.Operations.GroupBy import GroupBy
+
+from pandas import DataFrame, Series
+from typing import List
+
+class OutlierExplainerInterface(ExplainerInterface):
+
+    def __init__(self, operation, target: str,
+                 dir: int | str, control=None, hold_out: List = None, *args, **kwargs):
+        """
+        Initialize the OutlierExplainerInterface.
+        This class is responsible for interfacing between the outlier explainer and the pd-explain package.
+
+        :param operation: The operation to explain. Must be a GroupBy operation.
+        :param target: The target value to explain whether it is an outlier or not and why.
+        :param dir: The direction of the outlier. Can be 'low' or 'high' for low and high outliers respectively.
+        """
+        if hold_out is None:
+            hold_out = []
+
+        if not isinstance(operation, GroupBy):
+            raise ValueError("Outlier explainer only works on the results of a groupby operation")
+
+        res_col = None
+
+        for attr, dataset_relation in operation.iterate_attributes():
+            _, res_col = dataset_relation.get_source(attr), dataset_relation.get_result(attr)
+            res_col = res_col[~res_col.isnull()]
+            # Converting to a Series in case we get an ExpSeries (or some other overriden type), because those
+            # can interact badly due to overriden methods changing the behavior of the object
+            if res_col is not None:
+                res_col = Series(res_col)
+            break
+
+        # Get the aggregation attribute and method
+        try:
+            agg = list(operation.agg_dict.items())[0]
+        except:
+            agg = operation.agg_dict.items()
+
+        if type(operation.group_attributes) == list:
+            g_attr = operation.group_attributes[0]
+        else:
+            g_attr = operation.group_attributes
+
+        agg_attr, agg_method = agg[0], agg[1][0]
+
+
+
+        self._df_agg = res_col
+        # Like the above, converting to a DataFrame in case we get an ExpSeries or ExpDataFrame
+        self._df_in = DataFrame(operation.source_df)
+        self._g_att = g_attr
+        self._g_agg = agg_attr
+        self._agg_method = agg_method
+        self._target = target
+        if dir == "low":
+            dir = -1
+        elif dir == "high":
+            dir = 1
+        if dir not in [-1, 1]:
+            raise ValueError("dir must be either 'low' or 'high' or -1 or 1")
+        self._dir = dir
+        self._control = control
+        self._hold_out = hold_out
+        self._explanation = None
+
+    def generate_explanation(self):
+        explainer = OutlierExplainer()
+        self._explanation = explainer.explain(df_agg=self._df_agg, df_in=self._df_in, g_att=self._g_att, g_agg=self._g_agg,
+                                        agg_method=self._agg_method, target=self._target, dir=self._dir,
+                                        control=self._control, hold_out=self._hold_out)
+        return self._explanation
+
+    def can_visualize(self) -> bool:
+        return True
+
+    def visualize(self):
+        return self._explanation
+
+


### PR DESCRIPTION
Updated the integration of outlier explainer into pd-explain, to match the new reality where outlier explainer is part of the ExternalExplainers package and is treated as its own explainer, instead of as part of fedex.
Added a class for it that can be created via the ExplainerFactory, and also updated requirements.txt and setup.py to match.