### PR TITLE
f string fix for older Python versions

### DIFF
--- a/src/pd_explain/explainers/beta_explainers/metainsight_explainer.py
+++ b/src/pd_explain/explainers/beta_explainers/metainsight_explainer.py
@@ -721,8 +721,10 @@ class MetaInsightExplainer(ExplainerInterface):
 
         metainsight = self.metainsights[index]
 
+        metainsight = metainsight.__str__().replace("\n", "")
+
         textual_description = (f"Using automated analysis on the dataframe {self._source_name}, we have found "
-                               f"the common pattern in the data: {metainsight.__str__().replace("\n", "")}\n")
+                               f"the common pattern in the data: {metainsight}\n")
         if len(metainsight.exceptions) > 0:
             textual_description += f"Exceptions to this pattern were found:\n"
         textual_description += metainsight.get_exceptions_string()

--- a/src/pd_explain/explainers/explainer_interface.py
+++ b/src/pd_explain/explainers/explainer_interface.py
@@ -66,8 +66,7 @@ class ExplainerInterface(ABC):
             query = f"{operation.source_name}[{operation.attribute} {operation.operation_str} {operation.value}]"
             query_type = "filter"
         elif isinstance(operation, GroupBy):
-            query = (f"{operation.source_name}.groupby({', '.join(operation.group_attributes)
-            if isinstance(operation.group_attributes, list) else operation.group_attributes})"
+            query = (f"{operation.source_name}.groupby({', '.join(operation.group_attributes) if isinstance(operation.group_attributes, list) else operation.group_attributes})"
                            f".agg({operation.agg_dict})")
             query_type = "groupby"
         elif isinstance(operation, Join):

--- a/src/pd_explain/explainers/fedex_explainer.py
+++ b/src/pd_explain/explainers/fedex_explainer.py
@@ -396,7 +396,9 @@ class FedexExplainer(ExplainerInterface):
                               f"on dataframe {source_name}, we found (using automated analysis):\n"
                               f"{explanation_to_return_formatted}.\n")
         if added_explanation is not None:
+            added_explanations = added_explanation.replace('\n', ' ')
             explanation_string += (
                 f"Additionally, a LLM with limited context and no ability to query the data suggested "
-                f"that the cause of this change may be: {added_explanation.replace('\n', ' ')}.\n")
+                f"that the cause of this change may be: {added_explanations}.\n"
+            )
         return explanation_string

--- a/src/pd_explain/explainers/outlier_explainer.py
+++ b/src/pd_explain/explainers/outlier_explainer.py
@@ -139,10 +139,12 @@ class OutlierExplainerInterface(ExplainerInterface):
                                f"the value {self._target} was suspected to be a a {'high' if self._dir == 1 else 'low'} outlier. "
                                f"Using automated analysis, we found that: ")
         pattern = re.compile(r"\$\\bf(.*?)\$")
-        textual_description += f"{pattern.sub(r'\1', self._explanations).replace("\n", " ")}. \n"
+        subbed = pattern.sub(r'\1', self._explanations).replace("\n", " ")
+        textual_description += f"{subbed}.\n"
         if self._added_text is not None:
+            added_text = self._added_text['text'].replace('\n', ' ')
             textual_description += (f"Using a LLM to reason about this explanation, without access to the data or ability to "
                                     f"query it, it suggested that the following may provide additional context to the findings: "
-                                    f"{self._added_text['text'].replace('\n', ' ')}. \n")
+                                    f"{added_text}. \n")
 
         return textual_description

--- a/src/pd_explain/llm_integrations/automated_data_exploration/automated_data_exploration.py
+++ b/src/pd_explain/llm_integrations/automated_data_exploration/automated_data_exploration.py
@@ -632,7 +632,8 @@ class AutomatedDataExploration(LLMIntegrationInterface):
             client=client, user_query=user_query, num_iterations=max_iterations,
             data_description_str=data_description
         )
-        self.log.append(f"Initial plan generated: {plan.replace('\t', '&emsp;')}")
+        logged_plan = plan.replace("\t", "&emsp;") if plan else "No initial plan generated."
+        self.log.append(f"Initial plan generated: {logged_plan}")
         try:
             while iteration_num < max_iterations:
                 if verbose:

--- a/src/pd_explain/llm_integrations/explanation_reasoning.py
+++ b/src/pd_explain/llm_integrations/explanation_reasoning.py
@@ -3,8 +3,6 @@ import re
 import textwrap
 import os
 
-from numba.scripts.generate_lower_listing import description
-
 from pd_explain.llm_integrations.llm_integration_interface import LLMIntegrationInterface
 from pd_explain.llm_integrations.client import Client
 from pd_explain.llm_integrations import consts


### PR DESCRIPTION
Updated f-strings to not have \ characters inside brackets, complying…with versions prior to PEP-701 and no longer causing exceptions in Python versions older than 3.12.